### PR TITLE
move naive CSV parser into src/utils

### DIFF
--- a/src/lib/score-import/import-types/common/eamusement-iidx-csv/parser.test.ts
+++ b/src/lib/score-import/import-types/common/eamusement-iidx-csv/parser.test.ts
@@ -3,13 +3,13 @@ import t from "tap";
 import { MockMulterFile } from "test-utils/mock-multer";
 import { TestingIIDXEamusementCSV26, TestingIIDXEamusementCSV27 } from "test-utils/test-data";
 import ScoreImportFatalError from "../../../framework/score-importing/score-import-error";
-import GenericParseEamIIDXCSV, { NaiveCSVParse, ResolveHeaders } from "./parser";
+import GenericParseEamIIDXCSV, { IIDXCSVParse, ResolveHeaders } from "./parser";
 
 const logger = CreateLogCtx(__filename);
 
 t.test("#ParseEamusementCSV", (t) => {
 	t.test("Valid Rootage-Type CSV", (t) => {
-		const { iterableData, hasBeginnerAndLegg, version } = NaiveCSVParse(
+		const { iterableData, hasBeginnerAndLegg, version } = IIDXCSVParse(
 			TestingIIDXEamusementCSV26,
 			logger
 		);
@@ -22,7 +22,7 @@ t.test("#ParseEamusementCSV", (t) => {
 	});
 
 	t.test("Valid HV CSV", (t) => {
-		const { iterableData, hasBeginnerAndLegg, version } = NaiveCSVParse(
+		const { iterableData, hasBeginnerAndLegg, version } = IIDXCSVParse(
 			TestingIIDXEamusementCSV27,
 			logger
 		);
@@ -38,45 +38,16 @@ t.test("#ParseEamusementCSV", (t) => {
 		t.end();
 	});
 
-	t.test("Malicious Headers", (t) => {
-		// these headers are valid, because we don't check the contents
-		// only that it has the right amt of headers
-		const headerStr = `${"a,".repeat(26)}a`;
-
-		const TooShort = Buffer.from(`${headerStr}\n${"a,".repeat(3)}a`);
+	t.test("Broken CSV", (t) => {
+		// This is mostly tested in the unit tests for NaiveCSVParse (the general one), but we make sure that the CSVParseErrors are converted to ScoreImportFatalErrors
+		const buffer = Buffer.from(`${"a,".repeat(26)}a\n${"a,".repeat(3)}a`);
 
 		t.throws(
-			() => NaiveCSVParse(TooShort, logger),
+			() => IIDXCSVParse(buffer, logger),
 			new ScoreImportFatalError(400, "Row 1 has an invalid amount of cells (4, expected 27)")
 		);
 
-		const TooLong = Buffer.from(`${headerStr}\n${"a,".repeat(50)}a`);
-
-		t.throws(
-			() => NaiveCSVParse(TooLong, logger),
-			new ScoreImportFatalError(400, "Row 1 has an invalid amount of cells (51, expected 27)")
-		);
-
-		t.end();
-	});
-
-	t.test("Misshaped Rows", (t) => {
-		const LongHeaders = Buffer.from(`${"a".repeat(1000)},a`);
-
-		t.throws(
-			() => NaiveCSVParse(LongHeaders, logger),
-			new ScoreImportFatalError(400, "Headers were longer than 1000 characters long.")
-		);
-
-		const TooManyHeaders = Buffer.from(`${"a,".repeat(50)}a`);
-
-		t.throws(
-			() => NaiveCSVParse(TooManyHeaders, logger),
-			new ScoreImportFatalError(400, "Too many CSV headers.")
-		);
-
-		t.end();
-	});
+	})
 
 	t.test("Version Inference", (t) => {
 		const headerStr = `${"a,".repeat(26)}a`;
@@ -86,7 +57,7 @@ t.test("#ParseEamusementCSV", (t) => {
 		const InvalidVersions = Buffer.from(`${headerStr}\n${row}`);
 
 		t.throws(
-			() => NaiveCSVParse(InvalidVersions, logger),
+			() => IIDXCSVParse(InvalidVersions, logger),
 			new ScoreImportFatalError(
 				400,
 				"Invalid/Unsupported Eamusement Version Name GARBAGE VERSION."
@@ -96,14 +67,14 @@ t.test("#ParseEamusementCSV", (t) => {
 		const row27th = `HEROIC VERSE,foo bar,${"a,".repeat(24)}a`;
 		const row17th = `SIRIUS,foo bar,${"a,".repeat(24)}a`;
 
-		let { version } = NaiveCSVParse(
+		let { version } = IIDXCSVParse(
 			Buffer.from([headerStr, row27th, row17th].join("\n")),
 			logger
 		);
 
 		t.equal(version, "27", "Should pick the largest version from the list of scores.");
 
-		({ version } = NaiveCSVParse(
+		({ version } = IIDXCSVParse(
 			Buffer.from([headerStr, row17th, row27th].join("\n")),
 			logger
 		));

--- a/src/lib/score-import/import-types/common/eamusement-iidx-csv/parser.test.ts
+++ b/src/lib/score-import/import-types/common/eamusement-iidx-csv/parser.test.ts
@@ -39,7 +39,8 @@ t.test("#ParseEamusementCSV", (t) => {
 	});
 
 	t.test("Broken CSV", (t) => {
-		// This is mostly tested in the unit tests for NaiveCSVParse (the general one), but we make sure that the CSVParseErrors are converted to ScoreImportFatalErrors
+		// This is mostly tested in the unit tests for NaiveCSVParse (the general one),
+		// but we make sure that the CSVParseErrors are converted to ScoreImportFatalErrors
 		const buffer = Buffer.from(`${"a,".repeat(26)}a\n${"a,".repeat(3)}a`);
 
 		t.throws(

--- a/src/lib/score-import/import-types/common/eamusement-iidx-csv/parser.ts
+++ b/src/lib/score-import/import-types/common/eamusement-iidx-csv/parser.ts
@@ -99,9 +99,8 @@ export function IIDXCSVParse(csvBuffer: Buffer, logger: KtLogger) {
 	} catch (e) {
 		if (e instanceof CSVParseError) {
 			throw new ScoreImportFatalError(400, e.message);
-		} else {
-			throw e;
 		}
+		throw e;
 	}
 
 	const { hasBeginnerAndLegg } = ResolveHeaders(rawHeaders, logger);

--- a/src/lib/score-import/import-types/common/eamusement-iidx-csv/parser.ts
+++ b/src/lib/score-import/import-types/common/eamusement-iidx-csv/parser.ts
@@ -1,4 +1,5 @@
 import { KtLogger } from "lib/logger/logger";
+import { CSVParseError, NaiveCSVParse } from "utils/naive-csv-parser";
 import ScoreImportFatalError from "../../../framework/score-importing/score-import-error";
 import { ParserFunctionReturns } from "../types";
 import { EamusementScoreData, IIDXEamusementCSVContext, IIDXEamusementCSVData } from "./types";
@@ -90,46 +91,18 @@ export function ResolveHeaders(headers: string[], logger: KtLogger) {
 	);
 }
 
-/**
- * Parse a "naive CSV". A Naive CSV is one that does not properly escape " or , characters.
- * This also means that if konami ever have a song that has a comma, it will cause some serious problems.
- *
- * The reason we have a handrolled CSV parser instead of using an existing library is because eamusement CSVs are
- * invalid -- due to their lack of escaping. We have to do very manual parsing to actually make this work!
- */
-export function NaiveCSVParse(csvBuffer: Buffer, logger: KtLogger) {
-	const csvString = csvBuffer.toString("utf-8");
-
-	const csvData = csvString.split("\n");
-
-	const rawHeaders = [];
-	let headerLen = 0;
-	let curStr = "";
-
-	// looks like we're doing it like this.
-	for (const char of csvData[0]) {
-		headerLen++;
-
-		// safety checks to avoid getting DOS'd
-		if (headerLen > 1000) {
-			throw new ScoreImportFatalError(400, "Headers were longer than 1000 characters long.");
-		} else if (rawHeaders.length >= 50) {
-			// this does not *really* do what it seems.
-			// because there's inevitably something left in curStr in this fn
-			// this means that the above check is actually > 50 headers. Not
-			// >= 50.
-			throw new ScoreImportFatalError(400, "Too many CSV headers.");
-		}
-
-		if (char === ",") {
-			rawHeaders.push(curStr);
-			curStr = "";
+export function IIDXCSVParse(csvBuffer: Buffer, logger: KtLogger) {
+	let rawHeaders: string[];
+	let rawRows: string[][];
+	try {
+		({ rawHeaders, rawRows } = NaiveCSVParse(csvBuffer, logger));
+	} catch (e) {
+		if (e instanceof CSVParseError) {
+			throw new ScoreImportFatalError(400, e.message);
 		} else {
-			curStr += char;
+			throw e;
 		}
 	}
-
-	rawHeaders.push(curStr);
 
 	const { hasBeginnerAndLegg } = ResolveHeaders(rawHeaders, logger);
 
@@ -141,33 +114,7 @@ export function NaiveCSVParse(csvBuffer: Buffer, logger: KtLogger) {
 
 	let gameVersion = 0;
 
-	for (let i = 1; i < csvData.length; i++) {
-		const data = csvData[i];
-
-		// @security: This should probably be safetied from DOSing
-		const cells = data.split(",");
-
-		// weirdly enough, an empty string split on "," is an array with
-		// one empty value.
-		// regardless, this line skips empty rows
-		if (cells.length === 1) {
-			logger.verbose(`Skipped empty row ${i}.`);
-			continue;
-		}
-
-		if (cells.length !== rawHeaders.length) {
-			logger.info(
-				`eamusement-iidx csv has row (${i}) with invalid cell count of ${cells.length}, rejecting.`,
-				{
-					data,
-				}
-			);
-			throw new ScoreImportFatalError(
-				400,
-				`Row ${i} has an invalid amount of cells (${cells.length}, expected ${rawHeaders.length}).`
-			);
-		}
-
+	for (const cells of rawRows) {
 		const version = cells[0];
 		const title = cells[1].trim(); // konmai quality
 		const timestamp = cells[rawHeaders.length - 1].trim();
@@ -269,7 +216,7 @@ function GenericParseEamIIDXCSV(
 		);
 	}
 
-	const { hasBeginnerAndLegg, version, iterableData } = NaiveCSVParse(fileData.buffer, logger);
+	const { hasBeginnerAndLegg, version, iterableData } = IIDXCSVParse(fileData.buffer, logger);
 
 	logger.verbose("Successfully parsed CSV.");
 

--- a/src/utils/naive-csv-parser.test.ts
+++ b/src/utils/naive-csv-parser.test.ts
@@ -1,0 +1,103 @@
+import CreateLogCtx from "lib/logger/logger";
+import t from "tap";
+import { TestingIIDXEamusementCSV27 } from "test-utils/test-data";
+import { CSVParseError, NaiveCSVParse } from "./naive-csv-parser";
+
+const logger = CreateLogCtx(__filename);
+
+t.test("#ParseCSV", (t) => {
+	t.test("Valid Basic CSV", (t) => {
+		const headers = ["header1", "header2", "header3"];
+		const rows = [
+			["a", "b", "c"],
+			["d", "e", "f"],
+		];
+
+		const headersStr = headers.join(",");
+		const rowsStr = rows.map(r => r.join(",")).join("\n");
+
+		const csvBuffer = Buffer.from(`${headersStr}\n${rowsStr}`);
+
+		const { rawHeaders, rawRows } = NaiveCSVParse(csvBuffer, logger);
+		t.same(rawHeaders, headers);
+		t.same(rawRows, rows);
+
+		t.end();
+	});
+
+	t.test("Valid Evil CSV", (t) => {
+		const headers = ["header1", "\"header2\"", "hea\"der3"];
+		const rows = [
+			["a ", "bbbbbbbbbbbbbbbbbbbbbbbbbbb", ""],
+			["d", "\"", "冥"],
+		];
+
+		const headersStr = headers.join(",");
+		const rowsStr = rows.map(r => r.join(",")).join("\n");
+
+		const csvBuffer = Buffer.from(`${headersStr}\n${rowsStr}\n`);
+
+		const { rawHeaders, rawRows } = NaiveCSVParse(csvBuffer, logger);
+		t.same(rawHeaders, headers);
+		t.same(rawRows, rows);
+
+		t.end();
+	});
+
+	t.test("IIDX CSV", (t) => {
+		const { rawHeaders, rawRows } = NaiveCSVParse(
+			TestingIIDXEamusementCSV27,
+			logger
+		);
+
+		t.equal(rawHeaders.length, 41);
+		t.equal(rawRows.length, 1257);
+		for (let i = 0; i < rawRows.length; i++) {
+			t.equal(rawRows[i].length, 41, `Row ${i} is the correct size`);
+		}
+
+		t.end();
+	});
+
+	t.test("Malicious Headers", (t) => {
+		// these headers are valid, because we don't check the contents
+		// only that it has the right amt of headers
+		const headerStr = `${"a,".repeat(26)}a`;
+
+		const TooShort = Buffer.from(`${headerStr}\n${"a,".repeat(3)}a`);
+
+		t.throws(
+			() => NaiveCSVParse(TooShort, logger),
+			new CSVParseError("Row 1 has an invalid amount of cells (4, expected 27)")
+		);
+
+		const TooLong = Buffer.from(`${headerStr}\n${"a,".repeat(50)}a`);
+
+		t.throws(
+			() => NaiveCSVParse(TooLong, logger),
+			new CSVParseError("Row 1 has an invalid amount of cells (51, expected 27)")
+		);
+
+		t.end();
+	});
+
+	t.test("Misshaped Rows", (t) => {
+		const LongHeaders = Buffer.from(`${"a".repeat(1000)},a`);
+
+		t.throws(
+			() => NaiveCSVParse(LongHeaders, logger),
+			new CSVParseError("Headers were longer than 1000 characters long.")
+		);
+
+		const TooManyHeaders = Buffer.from(`${"a,".repeat(50)}a`);
+
+		t.throws(
+			() => NaiveCSVParse(TooManyHeaders, logger),
+			new CSVParseError("Too many CSV headers.")
+		);
+
+		t.end();
+	});
+
+	t.end();
+});

--- a/src/utils/naive-csv-parser.ts
+++ b/src/utils/naive-csv-parser.ts
@@ -1,0 +1,84 @@
+import { KtLogger } from "lib/logger/logger";
+
+export class CSVParseError extends Error {
+	constructor(description: string) {
+		super(description);
+		this.name = "CSVParseError";
+	}
+}
+
+/**
+ * Parse a "naive CSV". A Naive CSV is one that does not properly escape " or , characters.
+ * This also means that if konami ever have a song that has a comma, it will cause some serious problems.
+ *
+ * The reason we have a handrolled CSV parser instead of using an existing library is because eamusement CSVs are
+ * invalid -- due to their lack of escaping. We have to do very manual parsing to actually make this work!
+ */
+export function NaiveCSVParse(csvBuffer: Buffer, logger: KtLogger) {
+	const csvString = csvBuffer.toString("utf-8");
+
+	const csvData = csvString.split("\n");
+
+	const rawHeaders = [];
+	let headerLen = 0;
+	let curStr = "";
+
+	// looks like we're doing it like this.
+	for (const char of csvData[0]) {
+		headerLen++;
+
+		// safety checks to avoid getting DOS'd
+		if (headerLen > 1000) {
+			throw new CSVParseError("Headers were longer than 1000 characters long.");
+		} else if (rawHeaders.length >= 50) {
+			// this does not *really* do what it seems.
+			// because there's inevitably something left in curStr in this fn
+			// this means that the above check is actually > 50 headers. Not
+			// >= 50.
+			throw new CSVParseError("Too many CSV headers.");
+		}
+
+		if (char === ",") {
+			rawHeaders.push(curStr);
+			curStr = "";
+		} else {
+			curStr += char;
+		}
+	}
+
+	rawHeaders.push(curStr);
+
+	const rawRows = [];
+
+	for (let i = 1; i < csvData.length; i++) {
+		const data = csvData[i];
+
+		// @security: This should probably be safetied from DOSing
+		const cells = data.split(",");
+
+		// an empty string split on "," is an array with one empty value.
+		if (cells.length === 1) {
+			logger.verbose(`Skipped empty row ${i}.`);
+			continue;
+		}
+
+		if (cells.length !== rawHeaders.length) {
+			logger.info(
+				`csv has row (${i}) with invalid cell count of ${cells.length}, rejecting.`,
+				{
+					data,
+				}
+			);
+			throw new CSVParseError(
+				`Row ${i} has an invalid amount of cells (${cells.length}, expected ${rawHeaders.length}).`
+			);
+		}
+
+		rawRows.push(cells);
+	}
+
+	return {
+		rawHeaders,
+		rawRows,
+	};
+}


### PR DESCRIPTION
This shouldn't change the logic at all, although it does mean we load all of the cells into memory at once before operating on any of them (instead of creating the `EamusementScoreData` row-by-row as we parse).

Fixes #437.