### PR TITLE
Support early/late in USC

### DIFF
--- a/src/lib/score-import/import-types/ir/usc/converter.test.ts
+++ b/src/lib/score-import/import-types/ir/usc/converter.test.ts
@@ -31,7 +31,7 @@ t.test("#DeriveLamp", (t) => {
 		"PERFECT ULTIMATE CHAIN"
 	);
 
-	// error: 0 should not take priority over score 10million
+	// error: 0 => ultimate chain should not take priority over score 10million
 	t.equal(
 		DeriveLamp(
 			d(uscScore, {

--- a/src/lib/score-import/import-types/ir/usc/converter.ts
+++ b/src/lib/score-import/import-types/ir/usc/converter.ts
@@ -120,6 +120,8 @@ export const ConverterIRUSC: ConverterFunction<USCClientScore, IRUSCContext> = a
 			},
 			hitMeta: {
 				gauge: data.gauge,
+				fast: data.early,
+				slow: data.late,
 			},
 		},
 		scoreMeta: {

--- a/src/lib/score-import/import-types/ir/usc/parser.ts
+++ b/src/lib/score-import/import-types/ir/usc/parser.ts
@@ -14,11 +14,20 @@ const PR_USCIRScore: PrudenceSchema = {
 	crit: p.isPositiveInteger,
 	near: p.isPositiveInteger,
 	error: p.isPositiveInteger,
+	early: p.isPositiveInteger,
+	late: p.isPositiveInteger,
 	options: {
 		gaugeType: p.isIn(0, 1),
 		mirror: "boolean",
 		random: "boolean",
 		autoFlags: p.isInteger,
+	},
+	windows: {
+		perfect: p.isPositive,
+		good: p.isPositive,
+		hold: p.isPositive,
+		miss: p.isPositive,
+		slam: p.isPositive,
 	},
 };
 

--- a/src/server/router/ir/usc/_playtype/router.test.ts
+++ b/src/server/router/ir/usc/_playtype/router.test.ts
@@ -162,6 +162,8 @@ const USC_SCORE_PB: PBScoreDocument = {
 		},
 		hitMeta: {
 			gauge: 50,
+			fast: 50,
+			slow: 20,
 		},
 	},
 };
@@ -520,6 +522,8 @@ t.test("POST /scores", (t) => {
 			crit: 5,
 			near: 4,
 			error: 3,
+			early: 2,
+			late: 1,
 			options: {
 				gaugeType: 0,
 				gaugeOpt: 0,

--- a/src/server/router/ir/usc/_playtype/router.ts
+++ b/src/server/router/ir/usc/_playtype/router.ts
@@ -110,7 +110,7 @@ router.get("/", (req, res) =>
 		body: {
 			serverTime: Math.floor(Date.now() / 1000),
 			serverName: TachiConfig.NAME,
-			irVersion: "0.3.1-a",
+			irVersion: "0.3.3-a",
 		},
 	})
 );

--- a/src/server/router/ir/usc/_playtype/types.ts
+++ b/src/server/router/ir/usc/_playtype/types.ts
@@ -20,6 +20,8 @@ export interface USCClientScore {
 	crit: integer;
 	near: integer;
 	error: integer;
+	early: integer;
+	late: integer;
 	options: {
 		gaugeType: 0 | 1;
 		gaugeOpt: integer;

--- a/src/test-utils/test-data.ts
+++ b/src/test-utils/test-data.ts
@@ -226,6 +226,8 @@ export const uscScore: USCClientScore = {
 	error: 5,
 	near: 50,
 	gauge: 0.8,
+	early: 50,
+	late: 20,
 	options: {
 		autoFlags: 0,
 		gaugeOpt: 0,


### PR DESCRIPTION
Note: we immediately drop backcompat for v0.3.1-a. People should just update their game.