### PR TITLE
Get stuff a user did in the last (16) hours

### DIFF
--- a/src/lib/score-import/import-types/api/arc-iidx/converter.test.ts
+++ b/src/lib/score-import/import-types/api/arc-iidx/converter.test.ts
@@ -24,7 +24,7 @@ t.test("#ConvertAPIArcIIDX", (t) => {
 				game: "iidx",
 				importType: "api/arc-iidx",
 				timeAchieved: 1604784681894,
-				service: "ARC IIDX27",
+				service: "ARC IIDX28",
 				scoreData: {
 					grade: "A",
 					score: 1200,

--- a/src/lib/score-import/import-types/api/arc-iidx/converter.ts
+++ b/src/lib/score-import/import-types/api/arc-iidx/converter.ts
@@ -80,7 +80,7 @@ export const ConvertAPIArcIIDX: ConverterFunction<unknown, EmptyObject> = async 
 		game: "iidx",
 		importType,
 		timeAchieved,
-		service: "ARC IIDX27",
+		service: "ARC IIDX28",
 		scoreData: {
 			grade,
 			percent,

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto";
+import { ONE_HOUR } from "lib/constants/time";
 import { TachiConfig } from "lib/setup/config";
-import { Game, GamePTConfig, GetGameConfig, Playtypes } from "tachi-common";
+import { Game, GamePTConfig, GetGameConfig, Playtypes, integer } from "tachi-common";
 
 // https://github.com/sindresorhus/escape-string-regexp/blob/main/index.js
 // the developer of this has migrated everything to Force ES6 style modules,
@@ -127,4 +128,8 @@ export function IsValidURL(string: string) {
 
 export function Sleep(ms: number) {
 	return new Promise<void>((resolve) => setTimeout(() => resolve(), ms));
+}
+
+export function GetTimeXHoursAgo(hours: integer) {
+	return Date.now() - ONE_HOUR * hours;
 }

--- a/src/utils/queries/summary.ts
+++ b/src/utils/queries/summary.ts
@@ -1,0 +1,47 @@
+import db from "external/mongo/db";
+import { integer } from "tachi-common";
+import { GetTimeXHoursAgo } from "utils/misc";
+
+// Various utils related to the player summary endpoint.
+const REASONABLE_HOURS_AGO = 16;
+
+export function GetRecentPlaycount(userID: integer) {
+	const time = GetTimeXHoursAgo(REASONABLE_HOURS_AGO);
+
+	return db.scores.count({ userID, timeAchieved: { $gte: time } });
+}
+
+export function GetRecentSessions(userID: integer) {
+	const time = GetTimeXHoursAgo(REASONABLE_HOURS_AGO);
+
+	return db.sessions.find({
+		userID,
+		timeEnded: { $gte: time },
+	});
+}
+
+export async function GetRecentlyViewedFoldersAnyGPT(userID: integer) {
+	const time = GetTimeXHoursAgo(REASONABLE_HOURS_AGO);
+
+	const views = await db["recent-folder-views"].find(
+		{
+			userID,
+			lastViewed: { $gte: time },
+		},
+		{
+			sort: {
+				lastViewed: -1,
+			},
+			limit: 4,
+		}
+	);
+
+	const folders = await db.folders.find({
+		folderID: { $in: views.map((e) => e.folderID) },
+	});
+
+	// TODO: Sort recently viewed folders based on how recently viewed
+	// they were.
+
+	return folders;
+}


### PR DESCRIPTION
People playing back-to-back might experience session bleedover if set to 24 hours, so I've set the recent stats thing to 16 hours.

Fixes #453.