### PR TITLE
Destroy session if user attempts to login and already has a cookie lying around.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tachi-server",
-	"version": "2.0.27",
+	"version": "2.0.28",
 	"description": "A score tracking server.",
 	"main": "js/index.js",
 	"private": true,

--- a/src/lib/constants/version.ts
+++ b/src/lib/constants/version.ts
@@ -4,7 +4,7 @@
 
 const MAJOR = 2;
 const MINOR = 0;
-const PATCH = 27;
+const PATCH = 28;
 
 // As is with all front-facing zkldi projects, the version names for tachi-server
 // are from an album I like. In this case, the album is Portishead - Dummy.

--- a/src/server/router/api/v1/auth/router.test.ts
+++ b/src/server/router/api/v1/auth/router.test.ts
@@ -33,7 +33,7 @@ t.test("POST /api/v1/auth/login", (t) => {
 		t.end();
 	});
 
-	t.test("Should return 409 if user already logged in", async (t) => {
+	t.test("Should return 200 if user already logged in", async (t) => {
 		const res = await mockApi.post("/api/v1/auth/login").send({
 			username: "test_zkldi",
 			"!password": "password",
@@ -51,7 +51,8 @@ t.test("POST /api/v1/auth/login", (t) => {
 			})
 			.set("Cookie", cookie);
 
-		t.equal(res2.status, 409);
+		// even if they have a login already going, just let them log in.
+		t.equal(res2.status, 200);
 
 		t.end();
 	});

--- a/src/server/router/api/v1/auth/router.ts
+++ b/src/server/router/api/v1/auth/router.ts
@@ -61,14 +61,12 @@ router.post(
 	),
 	async (req, res) => {
 		if (req.session.tachi?.user.id) {
-			logger.info(`Dual log-in attempted from ${req.session.tachi.user.id}`);
-			return res.status(409).json({
-				success: false,
-				description: `You are already logged in as someone.`,
-			});
+			// @ts-expect-error Type error with the @types/express-session library,
+			// i think.
+			req.session.destroy();
 		}
 
-		logger.verbose(`received login request with username ${req.body.username} (${req.ip})`);
+		logger.verbose(`Received login request with username ${req.body.username} (${req.ip})`);
 
 		/* istanbul ignore next */
 		if (Environment.nodeEnv === "production" || Environment.nodeEnv === "staging") {
@@ -85,7 +83,7 @@ router.post(
 
 			logger.verbose("Captcha validated!");
 		} else {
-			logger.verbose("Skipped captcha check because not in production.");
+			logger.warn("Skipped captcha check because not in production.");
 		}
 
 		const requestedUser = await GetUserCaseInsensitive(req.body.username);

--- a/src/server/router/api/v1/auth/router.ts
+++ b/src/server/router/api/v1/auth/router.ts
@@ -61,9 +61,7 @@ router.post(
 	),
 	async (req, res) => {
 		if (req.session.tachi?.user.id) {
-			// @ts-expect-error Type error with the @types/express-session library,
-			// i think.
-			req.session.destroy();
+			req.session.tachi = undefined;
 		}
 
 		logger.verbose(`Received login request with username ${req.body.username} (${req.ip})`);


### PR DESCRIPTION
Not sure why this might happen, but it seems to happen sometimes. This is a hack fix until I can investigate it better.