### PR TITLE
Fix bug with Force Static Import not mattering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tachi-server",
-	"version": "2.1.6",
+	"version": "2.1.7",
 	"description": "A score tracking server.",
 	"main": "js/index.js",
 	"private": true,

--- a/src/lib/constants/version.ts
+++ b/src/lib/constants/version.ts
@@ -4,7 +4,7 @@
 
 const MAJOR = 2;
 const MINOR = 1;
-const PATCH = 6;
+const PATCH = 7;
 
 // As is with all front-facing zkldi projects, the version names for tachi-server
 // are from an album I like. In this case, the album is Portishead - Dummy.

--- a/src/server/router/ir/fervidex/router.test.ts
+++ b/src/server/router/ir/fervidex/router.test.ts
@@ -457,5 +457,20 @@ t.test("POST /ir/fervidex/profile/submit", (t) => {
 		t.end();
 	});
 
+	t.test("Should disallow requests from non INF2 if forceStaticImport is false.", async (t) => {
+		await db["fer-settings"].update({ userID: 1 }, { $set: { forceStaticImport: false } });
+
+		const res = await mockApi
+			.post("/ir/fervidex/profile/submit")
+			.set("Authorization", "Bearer mock_token")
+			.set("User-Agent", "fervidex/1.3.0")
+			.set("X-Software-Model", "LDJ:J:B:A:2020092900")
+			.send(ferStaticBody);
+
+		t.equal(res.statusCode, 400, "Should be rejected, as FSI is not set.");
+
+		t.end();
+	});
+
 	t.end();
 });

--- a/src/server/router/ir/fervidex/router.ts
+++ b/src/server/router/ir/fervidex/router.ts
@@ -92,7 +92,14 @@ const RequireInf2ModelHeaderOrForceStatic: RequestHandler = async (req, res, nex
 	}
 
 	try {
-		ParseEA3SoftID(swModel);
+		const { model } = ParseEA3SoftID(swModel);
+
+		if (model !== MODEL_INFINITAS_2) {
+			return res.status(400).json({
+				success: false,
+				error: `Refusing to perform static import from non-infinitas client. To do this anyway, enable Force Static Import.`,
+			});
+		}
 	} catch (err) {
 		logger.info(`Invalid softID from ${req[SYMBOL_TachiAPIAuth].userID!}.`, { err });
 		return res.status(400).json({


### PR DESCRIPTION
Whether the model was inf2 or not was never actually checked. This patch fixes that and adds a pertinent regression test.